### PR TITLE
Removed Link to Account Info

### DIFF
--- a/SpringMVCAnnotationOnlineStore/src/main/webapp/WEB-INF/pages/_menu.jsp
+++ b/SpringMVCAnnotationOnlineStore/src/main/webapp/WEB-INF/pages/_menu.jsp
@@ -26,7 +26,7 @@
 	                
 	                <c:if test="${pageContext.request.userPrincipal.name != null}">
 			        <li class="nav-item">
-	                    <a href="${pageContext.request.contextPath}/accountInfo" target="_blank" class="nav-link"><i class="nc-icon nc-single-02"></i>Welcome Back</a>
+	                    <a target="_blank" class="nav-link"><i class="nc-icon nc-single-02"></i>Welcome Back</a>
 	                	
 	                </li>
 	                <li class="nav-item">


### PR DESCRIPTION
There was a link to an Account Info page at the Welcome Back menu item that went to a draft looking page.  I just removed the link.